### PR TITLE
Add Application initialization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,11 +4,14 @@ Changelog
 5.0 (unreleased)
 ----------------
 
-- Drop support for Zope 2, require Zope 4 now.
+- Drop support for Zope 2, require Zope 4.0b5 now.
 
 - Drop `ZServer` dependency.
 
 - Add IPubFailure event handler so it writes error log entries again.
+
+- Bring back Application initialization (creation of SiteErrorLog in the
+  ZODB on first startup).
 
 
 4.0 (2016-07-22)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ INSTALL_REQUIRES = [
     'Acquisition',
     'transaction',
     'zExceptions',
-    'Zope2 >= 4.0.dev0',
+    'Zope >= 4.0b5',
     'zope.component',
     'zope.interface',
     'zope.event',

--- a/src/Products/SiteErrorLog/__init__.py
+++ b/src/Products/SiteErrorLog/__init__.py
@@ -14,8 +14,25 @@
 
 from . import SiteErrorLog
 
+def commit(note):
+    import transaction
+    transaction.get().note(note)
+    transaction.commit()
+
+def install_errorlog(app):
+    if hasattr(app, 'error_log'):
+        return
+
+    error_log = SiteErrorLog.SiteErrorLog()
+    app._setObject('error_log', error_log)
+    commit(u'Added site error_log at /error_log')
+
 
 def initialize(context):
     context.registerClass(SiteErrorLog.SiteErrorLog,
                           constructors=(SiteErrorLog.manage_addErrorLog,),
                           permission=SiteErrorLog.use_error_logging)
+
+    app = context.getApplication() # new API added in Zope 4.0b5
+    if app is not None:
+        install_errorlog(app)

--- a/src/Products/SiteErrorLog/tests/testInitialization.py
+++ b/src/Products/SiteErrorLog/tests/testInitialization.py
@@ -1,0 +1,83 @@
+##############################################################################
+#
+# Copyright (c) 2001, 2002 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from App.config import getConfiguration, setConfiguration
+from OFS.Application import Application, AppInitializer
+from Zope2.Startup.options import ZopeWSGIOptions
+
+good_cfg = """
+instancehome <<INSTANCE_HOME>>
+
+<zodb_db main>
+   mount-point /
+   <mappingstorage>
+      name mappingstorage
+   </mappingstorage>
+</zodb_db>
+"""
+
+original_config = None
+
+
+def getApp():
+    from App.ZApplication import ZApplicationWrapper
+    DB = getConfiguration().dbtab.getDatabase('/')
+    return ZApplicationWrapper(DB, 'Application', Application)()
+
+
+class TestInitialization(unittest.TestCase):
+    """ Test the application initialization """
+
+    def setUp(self):
+        global original_config
+        if original_config is None:
+            original_config = getConfiguration()
+        self.TEMPNAME = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import App.config
+        App.config.setConfiguration(original_config)
+        shutil.rmtree(self.TEMPNAME)
+        import Products
+        Products.__path__ = [d for d in Products.__path__
+                             if os.path.exists(d)]
+
+    def configure(self, text):
+        # We have to create a directory of our own since the existence
+        # of the directory is checked.  This handles this in a
+        # platform-independent way.
+        config_path = os.path.join(self.TEMPNAME, 'zope.conf')
+        with open(config_path, 'w') as fd:
+            fd.write(text.replace(u"<<INSTANCE_HOME>>", self.TEMPNAME))
+
+        options = ZopeWSGIOptions(config_path)()
+        config = options.configroot
+        self.assertEqual(config.instancehome, self.TEMPNAME)
+        setConfiguration(config)
+
+    def getOne(self):
+        app = getApp()
+        return AppInitializer(app)
+
+    def test_install_session_data_manager(self):
+        self.configure(good_cfg)
+        i = self.getOne()
+        i.install_products()
+        app = i.getApp()
+        self.assertEqual(app.error_log.meta_type, 'Site Error Log')

--- a/src/Products/SiteErrorLog/tests/testInitialization.py
+++ b/src/Products/SiteErrorLog/tests/testInitialization.py
@@ -17,23 +17,21 @@ import shutil
 import tempfile
 import unittest
 
+import Products
 from App.config import getConfiguration, setConfiguration
 from OFS.Application import Application, AppInitializer
 from Zope2.Startup.options import ZopeWSGIOptions
 
-good_cfg = """
-instancehome <<INSTANCE_HOME>>
+test_cfg = """
+instancehome {instance_home}
 
 <zodb_db main>
-   mount-point /
-   <mappingstorage>
-      name mappingstorage
-   </mappingstorage>
+    mount-point /
+    <mappingstorage>
+        name mappingstorage
+    </mappingstorage>
 </zodb_db>
 """
-
-original_config = None
-
 
 def getApp():
     from App.ZApplication import ZApplicationWrapper
@@ -42,42 +40,41 @@ def getApp():
 
 
 class TestInitialization(unittest.TestCase):
-    """ Test the application initialization """
+    """Test the application initialization"""
 
     def setUp(self):
-        global original_config
-        if original_config is None:
-            original_config = getConfiguration()
-        self.TEMPNAME = tempfile.mkdtemp()
+        self.original_config = getConfiguration()
+        self.TEMPDIR = tempfile.mkdtemp()
 
     def tearDown(self):
-        import App.config
-        App.config.setConfiguration(original_config)
-        shutil.rmtree(self.TEMPNAME)
-        import Products
-        Products.__path__ = [d for d in Products.__path__
+        setConfiguration(self.original_config)
+        shutil.rmtree(self.TEMPDIR)
+        Products.__path__ = [d
+                             for d in Products.__path__
                              if os.path.exists(d)]
 
-    def configure(self, text):
+    def configure(self, config):
         # We have to create a directory of our own since the existence
         # of the directory is checked.  This handles this in a
         # platform-independent way.
-        config_path = os.path.join(self.TEMPNAME, 'zope.conf')
+        config_path = os.path.join(self.TEMPDIR, 'zope.conf')
         with open(config_path, 'w') as fd:
-            fd.write(text.replace(u"<<INSTANCE_HOME>>", self.TEMPNAME))
+            fd.write(config.format(instance_home=self.TEMPDIR))
 
         options = ZopeWSGIOptions(config_path)()
         config = options.configroot
-        self.assertEqual(config.instancehome, self.TEMPNAME)
+        self.assertEqual(config.instancehome, self.TEMPDIR)
         setConfiguration(config)
 
-    def getOne(self):
+    def getInitializer(self):
         app = getApp()
         return AppInitializer(app)
 
     def test_install_session_data_manager(self):
-        self.configure(good_cfg)
-        i = self.getOne()
-        i.install_products()
-        app = i.getApp()
+        from Products.SiteErrorLog.SiteErrorLog import SiteErrorLog
+        self.configure(test_cfg)
+        initializer = self.getInitializer()
+        app = initializer.getApp()
+        initializer.install_products()
+        self.assertIsInstance(app.error_log, SiteErrorLog)
         self.assertEqual(app.error_log.meta_type, 'Site Error Log')


### PR DESCRIPTION
When splitting off this product from the main Zope repository, the
Application initialization has been removed. This code brings back the
automatically created site error log.