### PR TITLE
Change time format to include date

### DIFF
--- a/src/Products/SiteErrorLog/www/main.pt
+++ b/src/Products/SiteErrorLog/www/main.pt
@@ -75,7 +75,7 @@
 			<tbody>
 				<tr tal:repeat="entry entries">
 					<td class="zmi-time" style="white-space:nowrap">
-						<span tal:replace="python: modules['DateTime'].DateTime(entry['time']).ISO()">13:04:41</span>
+						<span tal:replace="python: modules['DateTime'].DateTime(entry['time']).ISO()"> 2022-07-01 11:59:15 </span>
 					</td>
 					<td class="zmi-username">
 						<span tal:replace="string: ${entry/username} (${entry/userid})">joe (joe)</span>

--- a/src/Products/SiteErrorLog/www/main.pt
+++ b/src/Products/SiteErrorLog/www/main.pt
@@ -75,7 +75,7 @@
 			<tbody>
 				<tr tal:repeat="entry entries">
 					<td class="zmi-time" style="white-space:nowrap">
-						<span tal:replace="python: modules['DateTime'].DateTime(entry['time']).ISO()"> 2022-07-01 11:59:15 </span>
+						<span tal:replace="python: modules['DateTime'].DateTime(entry['time']).ISO()">2022-07-01 11:59:15</span>
 					</td>
 					<td class="zmi-username">
 						<span tal:replace="string: ${entry/username} (${entry/userid})">joe (joe)</span>

--- a/src/Products/SiteErrorLog/www/main.pt
+++ b/src/Products/SiteErrorLog/www/main.pt
@@ -75,7 +75,7 @@
 			<tbody>
 				<tr tal:repeat="entry entries">
 					<td class="zmi-time" style="white-space:nowrap">
-						<span tal:replace="python: modules['DateTime'].DateTime(entry['time']).Time()">13:04:41</span>
+						<span tal:replace="python: modules['DateTime'].DateTime(entry['time']).ISO()">13:04:41</span>
 					</td>
 					<td class="zmi-username">
 						<span tal:replace="string: ${entry/username} (${entry/userid})">joe (joe)</span>


### PR DESCRIPTION
If there are not too many errors and Zope hasn't been restarted, it can be hard to tell when an error occurred without the date. The ISO() format is similar to the date format used elsewhere in the ZMI, with the necessary inclusion of seconds.