### PR TITLE
Drop Python 3.9, add Python 3.14, convert to PEP 420

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/zope-product
 #
 # EditorConfig Configuration file, for more details see:
-# http://EditorConfig.org
+# https://EditorConfig.org
 # EditorConfig is a convention description, that could be interpreted
 # by multiple editors to enforce common coding conventions for specific
 # file types

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,10 +21,10 @@ jobs:
     name: linting
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@v5
+    - uses: actions/setup-python@v6
       with:
-        python-version: 3.x
+        python-version: '3.13'
     - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  #v3.0.1
       with:
         extra_args: --all-files --show-diff-on-failure

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,28 +24,29 @@ jobs:
         config:
         # [Python version, tox env]
         - ["3.11", "release-check"]
-        - ["3.9", "py39"]
         - ["3.10", "py310"]
         - ["3.11", "py311"]
         - ["3.12", "py312"]
         - ["3.13", "py313"]
+        - ["3.14", "py314"]
         - ["3.11", "coverage"]
 
     runs-on: ${{ matrix.os[1] }}
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.config[1] }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - name: Install uv + caching
-      uses: astral-sh/setup-uv@v5
+      # astral/setup-uv@7.1.3
+      uses: astral-sh/setup-uv@5a7eac68fb9809dea845d802897dc5c723910fa3
       with:
         enable-cache: true
         cache-dependency-glob: |
           setup.*
           tox.ini
-        python-version: ${{ matrix.matrix.config[0] }}
+        python-version: ${{ matrix.config[0] }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Test
       if: ${{ !startsWith(runner.os, 'Mac') }}

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/zope-product
 [meta]
 template = "zope-product"
-commit-id = "a0de4e93"
+commit-id = "9fcd3d67"
 
 [python]
 with-pypy = false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 minimum_pre_commit_version: '3.6'
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: "6.0.1"
+    rev: "7.0.0"
     hooks:
     - id: isort
   - repo: https://github.com/hhatto/autopep8
@@ -12,16 +12,16 @@ repos:
     - id: autopep8
       args: [--in-place, --aggressive, --aggressive]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.1
+    rev: v3.21.0
     hooks:
     - id: pyupgrade
-      args: [--py39-plus]
+      args: [--py310-plus]
   - repo: https://github.com/isidentical/teyit
     rev: 0.4.3
     hooks:
     - id: teyit
   - repo: https://github.com/PyCQA/flake8
-    rev: "7.1.2"
+    rev: "7.3.0"
     hooks:
     - id: flake8
       additional_dependencies:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,14 +4,12 @@ Changelog
 7.0 (unreleased)
 ----------------
 
+- Switch to PEP 420 native namespace.
 
-- Add support for Python 3.13.
+- Add support for Python 3.12, 3.13 and 3.14.
 
-- Drop support for Python 3.8.
+- Drop support for Python 3.7, 3.8 and 3.9.
 
-- Add support for Python 3.12.
-
-- Drop support for Python 3.7.
 
 6.0 (2023-02-01)
 ----------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [build-system]
 requires = [
-    "setuptools == 75.8.2",
+    "setuptools >= 78.1.1,< 81",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@
 #
 ##############################################################################
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -45,20 +44,16 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Programming Language :: Python :: Implementation',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
-    packages=find_packages('src'),
-    namespace_packages=['Products'],
-    package_dir={'': 'src'},
-    python_requires='>=3.9',
+    python_requires='>=3.10',
     install_requires=[
-        'setuptools',
         'AccessControl',
         'Acquisition',
         'transaction',
@@ -68,6 +63,4 @@ setup(
         'zope.interface',
         'zope.event',
     ],
-    include_package_data=True,
-    zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -63,4 +63,5 @@ setup(
         'zope.interface',
         'zope.event',
     ],
+    include_package_data=True,
 )

--- a/src/Products/__init__.py
+++ b/src/Products/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)

--- a/tox.ini
+++ b/tox.ini
@@ -5,17 +5,17 @@ minversion = 3.18
 envlist =
     release-check
     lint
-    py39
     py310
     py311
     py312
     py313
+    py314
     coverage
 
 [testenv]
 skip_install = true
 deps =
-    setuptools == 75.8.2
+    setuptools >= 78.1.1,< 81
     zc.buildout
     wheel
 setenv =
@@ -37,7 +37,7 @@ description = ensure that the distribution is ready to release
 basepython = python3
 skip_install = true
 deps =
-    setuptools == 75.8.2
+    setuptools >= 78.1.1,< 81
     wheel
     twine
     build
@@ -47,7 +47,7 @@ deps =
 commands_pre =
 commands =
     check-manifest
-    check-python-versions --only setup.py,tox.ini,.github/workflows/tests.yml
+    check-python-versions --only pyproject.toml,setup.py,tox.ini,.github/workflows/tests.yml
     python -m build --sdist --no-isolation
     twine check dist/*
 


### PR DESCRIPTION
- Switch to PEP 420 native namespace.
- Add support for Python 3.14.
- Drop support for Python 3.9.

**The failing test on Python 3.14 is due to Zope 5.13 being used, it will clear up when the next Zope release is out**